### PR TITLE
fix: use correct settings for server launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,8 +17,8 @@
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
-      "program": "${workspaceFolder}/src/debugAdapter.ts",
-      "args": ["--server=4711"],
+      "program": "${workspaceFolder}/src/cli.ts",
+      "args": ["--port=4711"],
       "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "preLaunchTask": "npm: compile"
     },


### PR DESCRIPTION
Fix the settings for the server launch configuration.

I also noticed that source maps are referenced in the bundled algosdk source, however are not included.
This results in warnings being printed to console when launching the "Server" configuration.