### PR TITLE
Fix app state not being properly reset when stepping back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix app state not being properly reset when stepping back ([#19](https://github.com/algorand/avm-debugger/pull/19))
+
 ## [0.1.2] - 2023-12-14
 
 ### Fixed

--- a/src/common/traceReplayEngine.ts
+++ b/src/common/traceReplayEngine.ts
@@ -981,7 +981,7 @@ export class ProgramStackFrame extends TraceReplayStackFrame {
     if (typeof this.initialAppState !== 'undefined') {
       this.engine.currentAppState.set(
         this.currentAppID()!,
-        this.initialAppState,
+        this.initialAppState.clone(),
       );
     }
   }

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1722,7 +1722,7 @@ describe('Debug Adapter Tests', () => {
         assert.strictEqual(stoppedEvent.body.reason, 'step');
       }
 
-      // Ensure that the local state at the beginning does not show changes that will happen later
+      // Ensure that the box state at the beginning does not show changes that will happen later
       await assertVariables(client, {
         pc: 6,
         stack: [1058],


### PR DESCRIPTION
The initial app state was being polluted after some instances of stepping back. This PR fixes the issue.