### PR TITLE
Properly handle failing clear state programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix app state not being properly reset when stepping back ([#19](https://github.com/algorand/avm-debugger/pull/19))
+- Properly handle failing clear state programs ([#20](https://github.com/algorand/avm-debugger/pull/20))
 
 ## [0.1.2] - 2023-12-14
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -47,6 +47,10 @@ Execution errors will be reported by the debugger. Since any error stops the exe
 transaction group, the debugger will not allow you to advance after an error. You can however step
 backwards to inspect what happened prior to the error.
 
+> Note: There are a special class of errors which do not stop the execution of a transaction group.
+> These are errors or rejections that occur in a clear state program. The debugger will still show
+> these errors, and it will allow you to continue execution over them.
+
 ![An error in the debugger](images/error.png)
 
 ## Inspect program state

--- a/algosdk/client/v2/algod/models/types.d.ts
+++ b/algosdk/client/v2/algod/models/types.d.ts
@@ -2317,6 +2317,17 @@ export declare class SimulationTransactionExecTrace extends BaseModel {
      */
     clearStateProgramTrace?: SimulationOpcodeTraceUnit[];
     /**
+     * If true, indicates that the clear state program failed and any persistent state
+     * changes it produced should be reverted once the program exits.
+     */
+    clearStateRollback?: boolean;
+    /**
+     * The error message explaining why the clear state program failed. This field will
+     * only be populated if clear-state-rollback is true and the failure was due to an
+     * execution error.
+     */
+    clearStateRollbackError?: string;
+    /**
      * An array of SimulationTransactionExecTrace representing the execution trace of
      * any inner transactions executed.
      */
@@ -2335,16 +2346,23 @@ export declare class SimulationTransactionExecTrace extends BaseModel {
      * @param approvalProgramTrace - Program trace that contains a trace of opcode effects in an approval program.
      * @param clearStateProgramHash - SHA512_256 hash digest of the clear state program executed in transaction.
      * @param clearStateProgramTrace - Program trace that contains a trace of opcode effects in a clear state program.
+     * @param clearStateRollback - If true, indicates that the clear state program failed and any persistent state
+     * changes it produced should be reverted once the program exits.
+     * @param clearStateRollbackError - The error message explaining why the clear state program failed. This field will
+     * only be populated if clear-state-rollback is true and the failure was due to an
+     * execution error.
      * @param innerTrace - An array of SimulationTransactionExecTrace representing the execution trace of
      * any inner transactions executed.
      * @param logicSigHash - SHA512_256 hash digest of the logic sig executed in transaction.
      * @param logicSigTrace - Program trace that contains a trace of opcode effects in a logic sig.
      */
-    constructor({ approvalProgramHash, approvalProgramTrace, clearStateProgramHash, clearStateProgramTrace, innerTrace, logicSigHash, logicSigTrace, }: {
+    constructor({ approvalProgramHash, approvalProgramTrace, clearStateProgramHash, clearStateProgramTrace, clearStateRollback, clearStateRollbackError, innerTrace, logicSigHash, logicSigTrace, }: {
         approvalProgramHash?: string | Uint8Array;
         approvalProgramTrace?: SimulationOpcodeTraceUnit[];
         clearStateProgramHash?: string | Uint8Array;
         clearStateProgramTrace?: SimulationOpcodeTraceUnit[];
+        clearStateRollback?: boolean;
+        clearStateRollbackError?: string;
         innerTrace?: SimulationTransactionExecTrace[];
         logicSigHash?: string | Uint8Array;
         logicSigTrace?: SimulationOpcodeTraceUnit[];

--- a/algosdk/client/v2/algod/models/types.js
+++ b/algosdk/client/v2/algod/models/types.js
@@ -2706,12 +2706,17 @@ class SimulationTransactionExecTrace extends basemodel_1.default {
      * @param approvalProgramTrace - Program trace that contains a trace of opcode effects in an approval program.
      * @param clearStateProgramHash - SHA512_256 hash digest of the clear state program executed in transaction.
      * @param clearStateProgramTrace - Program trace that contains a trace of opcode effects in a clear state program.
+     * @param clearStateRollback - If true, indicates that the clear state program failed and any persistent state
+     * changes it produced should be reverted once the program exits.
+     * @param clearStateRollbackError - The error message explaining why the clear state program failed. This field will
+     * only be populated if clear-state-rollback is true and the failure was due to an
+     * execution error.
      * @param innerTrace - An array of SimulationTransactionExecTrace representing the execution trace of
      * any inner transactions executed.
      * @param logicSigHash - SHA512_256 hash digest of the logic sig executed in transaction.
      * @param logicSigTrace - Program trace that contains a trace of opcode effects in a logic sig.
      */
-    constructor({ approvalProgramHash, approvalProgramTrace, clearStateProgramHash, clearStateProgramTrace, innerTrace, logicSigHash, logicSigTrace, }) {
+    constructor({ approvalProgramHash, approvalProgramTrace, clearStateProgramHash, clearStateProgramTrace, clearStateRollback, clearStateRollbackError, innerTrace, logicSigHash, logicSigTrace, }) {
         super();
         this.approvalProgramHash =
             typeof approvalProgramHash === 'string'
@@ -2723,6 +2728,8 @@ class SimulationTransactionExecTrace extends basemodel_1.default {
                 ? (0, binarydata_1.base64ToBytes)(clearStateProgramHash)
                 : clearStateProgramHash;
         this.clearStateProgramTrace = clearStateProgramTrace;
+        this.clearStateRollback = clearStateRollback;
+        this.clearStateRollbackError = clearStateRollbackError;
         this.innerTrace = innerTrace;
         this.logicSigHash =
             typeof logicSigHash === 'string'
@@ -2734,6 +2741,8 @@ class SimulationTransactionExecTrace extends basemodel_1.default {
             approvalProgramTrace: 'approval-program-trace',
             clearStateProgramHash: 'clear-state-program-hash',
             clearStateProgramTrace: 'clear-state-program-trace',
+            clearStateRollback: 'clear-state-rollback',
+            clearStateRollbackError: 'clear-state-rollback-error',
             innerTrace: 'inner-trace',
             logicSigHash: 'logic-sig-hash',
             logicSigTrace: 'logic-sig-trace',
@@ -2751,6 +2760,8 @@ class SimulationTransactionExecTrace extends basemodel_1.default {
             clearStateProgramTrace: typeof data['clear-state-program-trace'] !== 'undefined'
                 ? data['clear-state-program-trace'].map(SimulationOpcodeTraceUnit.from_obj_for_encoding)
                 : undefined,
+            clearStateRollback: data['clear-state-rollback'],
+            clearStateRollbackError: data['clear-state-rollback-error'],
             innerTrace: typeof data['inner-trace'] !== 'undefined'
                 ? data['inner-trace'].map(SimulationTransactionExecTrace.from_obj_for_encoding)
                 : undefined,

--- a/sampleWorkspace/.vscode/launch.json
+++ b/sampleWorkspace/.vscode/launch.json
@@ -143,6 +143,26 @@
       "programSourcesDescriptionFile": "${workspaceFolder}/errors/logicsig-after-error/sources.json",
 
       "stopOnEntry": true
+    },
+    {
+      "type": "avm",
+      "request": "launch",
+      "name": "Clear State Rejection",
+
+      "simulateTraceFile": "${workspaceFolder}/errors/clear-state/rejection-response.json",
+      "programSourcesDescriptionFile": "${workspaceFolder}/errors/clear-state/sources.json",
+
+      "stopOnEntry": true
+    },
+    {
+      "type": "avm",
+      "request": "launch",
+      "name": "Clear State Error",
+
+      "simulateTraceFile": "${workspaceFolder}/errors/clear-state/error-response.json",
+      "programSourcesDescriptionFile": "${workspaceFolder}/errors/clear-state/sources.json",
+
+      "stopOnEntry": true
     }
   ]
 }

--- a/sampleWorkspace/errors/clear-state/error-response.json
+++ b/sampleWorkspace/errors/clear-state/error-response.json
@@ -1,0 +1,180 @@
+{
+  "exec-trace-config": {
+    "enable": true,
+    "scratch-change": true,
+    "stack-change": true,
+    "state-change": true
+  },
+  "initial-states": {
+    "app-initial-states": [
+      {
+        "app-globals": {
+          "kvs": [
+            {
+              "key": "Y291bnRlcg==",
+              "value": {
+                "type": 2,
+                "uint": 4
+              }
+            }
+          ]
+        },
+        "id": 1001
+      }
+    ]
+  },
+  "last-round": 4,
+  "txn-groups": [
+    {
+      "app-budget-added": 700,
+      "app-budget-consumed": 14,
+      "txn-results": [
+        {
+          "app-budget-consumed": 14,
+          "exec-trace": {
+            "clear-state-program-hash": "ZY8dOBgLGyQoqiQqBH1PSo+dCcJIDpwqLzqLBvNJaNk=",
+            "clear-state-program-trace": [
+              {
+                "pc": 1
+              },
+              {
+                "pc": 4,
+                "stack-additions": [
+                  {
+                    "bytes": "Y291bnRlcg==",
+                    "type": 1
+                  }
+                ]
+              },
+              {
+                "pc": 13,
+                "stack-additions": [
+                  {
+                    "bytes": "Y291bnRlcg==",
+                    "type": 1
+                  },
+                  {
+                    "bytes": "Y291bnRlcg==",
+                    "type": 1
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 14,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 4
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 15,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ]
+              },
+              {
+                "pc": 16,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 5
+                  }
+                ],
+                "stack-pop-count": 2
+              },
+              {
+                "pc": 17,
+                "stack-pop-count": 2,
+                "state-changes": [
+                  {
+                    "app-state-type": "g",
+                    "key": "Y291bnRlcg==",
+                    "new-value": {
+                      "type": 2,
+                      "uint": 5
+                    },
+                    "operation": "w"
+                  }
+                ]
+              },
+              {
+                "pc": 18,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1001
+                  }
+                ]
+              },
+              {
+                "pc": 20,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 23,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 3
+                  }
+                ]
+              },
+              {
+                "pc": 25,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ]
+              },
+              {
+                "pc": 26,
+                "stack-additions": [
+                  {
+                    "type": 2
+                  }
+                ],
+                "stack-pop-count": 2
+              },
+              {
+                "pc": 27,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 30
+              }
+            ],
+            "clear-state-rollback": true,
+            "clear-state-rollback-error": "invalid ApplicationArgs index 0"
+          },
+          "txn-result": {
+            "pool-error": "",
+            "txn": {
+              "sig": "Q0UCQSgS7KBWT+N/xXFELqajmZatiAp4NZgoOJRLoEKRGwUkr0/E7BMOybspT7BIVa0vCpjN0l8O/ePdcs9EAg==",
+              "txn": {
+                "apan": 3,
+                "apid": 1001,
+                "fee": 1000,
+                "fv": 4,
+                "gh": "dsgtQlDfh3EgBWQs+f6G+ZorH4WiY2Vmzu7sGgfcbng=",
+                "lv": 1004,
+                "note": "sV/32BiFDlA=",
+                "snd": "EI4F6GLWBIUTRCC4EJK7TXKY4AEW6DOZNUXYZXYEHBPXNFJU53REVFPI34",
+                "type": "appl"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "version": 2
+}

--- a/sampleWorkspace/errors/clear-state/rejection-response.json
+++ b/sampleWorkspace/errors/clear-state/rejection-response.json
@@ -1,0 +1,206 @@
+{
+  "exec-trace-config": {
+    "enable": true,
+    "scratch-change": true,
+    "stack-change": true,
+    "state-change": true
+  },
+  "initial-states": {
+    "app-initial-states": [
+      {
+        "app-globals": {
+          "kvs": [
+            {
+              "key": "Y291bnRlcg==",
+              "value": {
+                "type": 2,
+                "uint": 4
+              }
+            }
+          ]
+        },
+        "id": 1001
+      }
+    ]
+  },
+  "last-round": 4,
+  "txn-groups": [
+    {
+      "app-budget-added": 700,
+      "app-budget-consumed": 16,
+      "txn-results": [
+        {
+          "app-budget-consumed": 16,
+          "exec-trace": {
+            "clear-state-program-hash": "ZY8dOBgLGyQoqiQqBH1PSo+dCcJIDpwqLzqLBvNJaNk=",
+            "clear-state-program-trace": [
+              {
+                "pc": 1
+              },
+              {
+                "pc": 4,
+                "stack-additions": [
+                  {
+                    "bytes": "Y291bnRlcg==",
+                    "type": 1
+                  }
+                ]
+              },
+              {
+                "pc": 13,
+                "stack-additions": [
+                  {
+                    "bytes": "Y291bnRlcg==",
+                    "type": 1
+                  },
+                  {
+                    "bytes": "Y291bnRlcg==",
+                    "type": 1
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 14,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 4
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 15,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ]
+              },
+              {
+                "pc": 16,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 5
+                  }
+                ],
+                "stack-pop-count": 2
+              },
+              {
+                "pc": 17,
+                "stack-pop-count": 2,
+                "state-changes": [
+                  {
+                    "app-state-type": "g",
+                    "key": "Y291bnRlcg==",
+                    "new-value": {
+                      "type": 2,
+                      "uint": 5
+                    },
+                    "operation": "w"
+                  }
+                ]
+              },
+              {
+                "pc": 18,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1001
+                  }
+                ]
+              },
+              {
+                "pc": 20,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 23,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 3
+                  }
+                ]
+              },
+              {
+                "pc": 25,
+                "stack-additions": [
+                  {
+                    "type": 2,
+                    "uint": 1
+                  }
+                ]
+              },
+              {
+                "pc": 26,
+                "stack-additions": [
+                  {
+                    "type": 2
+                  }
+                ],
+                "stack-pop-count": 2
+              },
+              {
+                "pc": 27,
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 30,
+                "stack-additions": [
+                  {
+                    "bytes": "AAAAAAAAAAA=",
+                    "type": 1
+                  }
+                ]
+              },
+              {
+                "pc": 33,
+                "stack-additions": [
+                  {
+                    "type": 2
+                  }
+                ],
+                "stack-pop-count": 1
+              },
+              {
+                "pc": 34,
+                "stack-additions": [
+                  {
+                    "type": 2
+                  }
+                ],
+                "stack-pop-count": 1
+              }
+            ],
+            "clear-state-rollback": true
+          },
+          "txn-result": {
+            "pool-error": "",
+            "txn": {
+              "sig": "z0+Cs2OxDfDUTVEJkQjiYMOaG8EBEQe6iY1QtusTZ7/4pX1dcYBmC9aWKDTdA4bjvjCLFzEc7bp4J9V3E/rvCA==",
+              "txn": {
+                "apaa": [
+                  "AAAAAAAAAAA="
+                ],
+                "apan": 3,
+                "apid": 1001,
+                "fee": 1000,
+                "fv": 4,
+                "gh": "dsgtQlDfh3EgBWQs+f6G+ZorH4WiY2Vmzu7sGgfcbng=",
+                "lv": 1004,
+                "note": "1DI44/pGiCI=",
+                "snd": "EI4F6GLWBIUTRCC4EJK7TXKY4AEW6DOZNUXYZXYEHBPXNFJU53REVFPI34",
+                "type": "appl"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "version": 2
+}

--- a/sampleWorkspace/errors/clear-state/rejection-response.json
+++ b/sampleWorkspace/errors/clear-state/rejection-response.json
@@ -183,9 +183,7 @@
             "txn": {
               "sig": "z0+Cs2OxDfDUTVEJkQjiYMOaG8EBEQe6iY1QtusTZ7/4pX1dcYBmC9aWKDTdA4bjvjCLFzEc7bp4J9V3E/rvCA==",
               "txn": {
-                "apaa": [
-                  "AAAAAAAAAAA="
-                ],
+                "apaa": ["AAAAAAAAAAA="],
                 "apan": 3,
                 "apid": 1001,
                 "fee": 1000,

--- a/sampleWorkspace/errors/clear-state/returnFirstAppArg.teal
+++ b/sampleWorkspace/errors/clear-state/returnFirstAppArg.teal
@@ -1,0 +1,19 @@
+#pragma version 6
+byte "counter"
+dup
+app_global_get
+int 1
++
+app_global_put
+txn ApplicationID
+bz end
+txn OnCompletion
+int OptIn
+==
+bnz end
+txn ApplicationArgs 0
+btoi
+return
+end:
+int 1
+return

--- a/sampleWorkspace/errors/clear-state/returnFirstAppArg.teal.tok.map
+++ b/sampleWorkspace/errors/clear-state/returnFirstAppArg.teal.tok.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["returnFirstAppArg.teal"],"names":[],"mappings":";;;;AACA;;;;;;;;;AACA;AACA;AACA;AACA;AACA;AACA;;AACA;;;AACA;;AACA;AACA;AACA;;;AACA;;;AACA;AACA;AAEA;AACA"}

--- a/sampleWorkspace/errors/clear-state/sources.json
+++ b/sampleWorkspace/errors/clear-state/sources.json
@@ -1,0 +1,8 @@
+{
+  "txn-group-sources": [
+    {
+      "sourcemap-location": "./returnFirstAppArg.teal.tok.map",
+      "hash": "ZY8dOBgLGyQoqiQqBH1PSo+dCcJIDpwqLzqLBvNJaNk="
+    }
+  ]
+}


### PR DESCRIPTION
Use the new fields introduced in https://github.com/algorand/go-algorand/pull/5842 to properly handle failing clear state programs.

This introduces two behavior changes:
* The debugger will show an error if a clear state program rejects or errors. This error does not cause the transaction to fail, and it can be stepped over by the debugger.
* Clear state programs will have their app state changes rolled back if they fail. However, the debugger had no way of knowing if this happened prior to this PR. Now it will properly roll back state.